### PR TITLE
Add CI workflow with PHP 8.3-8.5 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.3', '8.4', '8.5']
+
+    name: PHP ${{ matrix.php-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Omit `$idPrefix` for unprefixed IDs.
 
 ## Requirements
 
-- PHP >= 8.3
+- PHP 8.3, 8.4, or 8.5
 - Laravel 11 or 12
 - [alesitom/hybrid-id](https://github.com/alesitom/hybridId_package) ^3.2 (installed automatically)
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow testing PHP 8.3, 8.4, and 8.5
- Update README requirements to reflect tested versions

## Test plan
- [x] CI passes on all three PHP versions