### PR TITLE
chore: support hybrid-id v4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [2.2.0] - 2026-04-22
+
+### Changed
+- Require `alesitom/hybrid-id: ^4.4` (was `^4.1`). Tested against v4.4.0.
+
+### Compatibility note — hybrid-id v4.4.0
+- `HybridIdGenerator::getNode()` now returns `?string` (was `string`), returning `null` for nodeless profiles (`compact` and custom profiles with `node: 0`). The Laravel adapter itself does not call this method, so no user-facing change; only relevant if you fetch the underlying generator via the container and call `getNode()` on a nodeless profile.
+- `ProfileRegistryInterface::register()` has a new optional `int $node = 2` parameter. Custom implementations of this interface (uncommon in Laravel apps) must add the new parameter.
+
+## [2.1.0] - 2026-02
+
+Previous releases are documented only on GitHub: https://github.com/alesitom/hybrid-id-laravel/releases

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "require": {
         "php": "^8.3",
-        "alesitom/hybrid-id": "^4.1",
+        "alesitom/hybrid-id": "^4.4",
         "illuminate/database": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0"
     },


### PR DESCRIPTION
## Summary

Bump `alesitom/hybrid-id` constraint from `^4.1` to `^4.4` to track the newly-released v4.4.0 of the core package.

## v4.4.0 compatibility notes

- `HybridIdGenerator::getNode()` now returns `?string` (was `string`), returning `null` for nodeless profiles. The Laravel adapter does not call `getNode()` internally, so there is no user-facing change unless you fetch the underlying generator via the container and call `getNode()` on a nodeless profile yourself.
- `ProfileRegistryInterface::register()` has a new optional `int $node = 2` parameter. Custom implementations (uncommon) must add it.

## Test plan

- [x] Local `phpunit` (ServiceProviderTest, 8/8 pass — HasHybridIdTest skipped locally due to missing `pdo_sqlite`)
- [x] Local `phpstan` max level clean
- [x] Local `php-cs-fixer` clean
- [ ] CI green on PHP 8.3/8.4/8.5 + coverage